### PR TITLE
Epilys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ inkwell_internals = { path = "./internal_macros", version = "0.2.0" }
 libc = "0.2"
 llvm-sys = "100.0.1"
 once_cell = "1.2"
-parking_lot = "0.10"
+parking_lot = "0.11"
 regex = "1"
 static-alloc = { version = "0.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ target-sparc = []
 target-bpf = []
 target-lanai = []
 target-webassembly = []
+target-riscv = []
 target-all = [
     "target-x86",
     "target-arm",
@@ -57,7 +58,8 @@ target-all = [
     "target-sparc",
     "target-bpf",
     "target-lanai",
-    "target-webassembly"
+    "target-webassembly",
+    "target-riscv"
 ]
 experimental = ["static-alloc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ experimental = ["static-alloc"]
 
 [dependencies]
 either = "1.5"
-inkwell_internals = { path = "./internal_macros", version = "0.1.0" }
+inkwell_internals = { path = "./internal_macros", version = "0.2.0" }
 libc = "0.2"
 llvm-sys = "100.0.1"
 once_cell = "1.2"

--- a/internal_macros/Cargo.toml
+++ b/internal_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inkwell_internals"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniel Kolsoi <thadan64@gmail.com>"]
 description = "Internal macro crate for inkwell"
 edition = "2018"

--- a/src/context.rs
+++ b/src/context.rs
@@ -893,7 +893,7 @@ impl Drop for Context {
     }
 }
 
-/// A `ContextRef` is a smart pointer allowing borrowed access to a a type's `Context`.
+/// A `ContextRef` is a smart pointer allowing borrowed access to a type's `Context`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ContextRef<'ctx> {
     context: ManuallyDrop<Context>,
@@ -912,7 +912,7 @@ impl<'ctx> ContextRef<'ctx> {
     #[cfg(feature = "experimental")]
     pub fn get(&self) -> &'ctx Context {
         // Safety: Although strictly untrue that a local reference to the context field
-        // is guarenteed to live for the entirety of 'ctx:
+        // is guaranteed to live for the entirety of 'ctx:
         // 1) ContextRef cannot outlive 'ctx
         // 2) Any method called called with this context object will inherit 'ctx,
         // which is its proper lifetime and does not point into this context object

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -89,7 +89,6 @@
 use crate::basic_block::BasicBlock;
 use crate::context::Context;
 use crate::module::Module;
-use crate::support::to_c_str;
 use crate::values::AsValueRef;
 use crate::values::BasicValueEnum;
 use crate::values::{InstructionValue, PointerValue};
@@ -175,22 +174,19 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         debug_info_for_profiling: bool,
     ) -> DICompileUnit<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateCompileUnit;
-        let producer = to_c_str(producer);
-        let flags = to_c_str(flags);
-        let split_name = to_c_str(split_name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateCompileUnit(
                 self.builder,
                 language.into(),
                 file.metadata_ref,
-                producer.as_ptr(),
-                producer.to_bytes().len(),
+                producer.as_ptr() as _,
+                producer.len(),
                 is_optimized as _,
-                flags.as_ptr(),
-                flags.to_bytes().len(),
+                flags.as_ptr() as _,
+                flags.len(),
                 runtime_ver,
-                split_name.as_ptr(),
-                split_name.to_bytes().len(),
+                split_name.as_ptr() as _,
+                split_name.len(),
                 kind.into(),
                 dwo_id,
                 split_debug_inlining as _,
@@ -235,17 +231,16 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         is_optimized: bool,
     ) -> DISubprogram<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateFunction;
-        let linkage_name = to_c_str(linkage_name.unwrap_or(name));
-        let name = to_c_str(name);
+        let linkage_name = linkage_name.unwrap_or(name);
 
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateFunction(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
-                linkage_name.as_ptr(),
-                linkage_name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
+                linkage_name.as_ptr() as _,
+                linkage_name.len(),
                 file.metadata_ref,
                 line_no,
                 ditype.metadata_ref,
@@ -289,15 +284,13 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     /// Create a file scope.
     pub fn create_file(&self, filename: &str, directory: &str) -> DIFile<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateFile;
-        let filename = to_c_str(filename);
-        let directory = to_c_str(directory);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateFile(
                 self.builder,
-                filename.as_ptr(),
-                filename.to_bytes().len(),
-                directory.as_ptr(),
-                directory.to_bytes().len(),
+                filename.as_ptr() as _,
+                filename.len(),
+                directory.as_ptr() as _,
+                directory.len(),
             )
         };
         DIFile {
@@ -348,12 +341,11 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
             // (name, size_in_bits, encoding).
             panic!("basic types must have names");
         }
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateBasicType(
                 self.builder,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 size_in_bits,
                 encoding,
             )
@@ -375,12 +367,11 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         flags: DIFlags,
     ) -> DIBasicType<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateBasicType;
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateBasicType(
                 self.builder,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 size_in_bits,
                 encoding,
                 flags.into(),
@@ -403,13 +394,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         scope: DIScope<'ctx>,
     ) -> DIDerivedType<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateTypedef;
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateTypedef(
                 self.builder,
                 ditype.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 scope.metadata_ref,
@@ -433,13 +423,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         align_in_bits: u32,
     ) -> DIDerivedType<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateTypedef;
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateTypedef(
                 self.builder,
                 ditype.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 scope.metadata_ref,
@@ -469,14 +458,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateUnionType;
         let mut elements: Vec<LLVMMetadataRef> =
             elements.into_iter().map(|dt| dt.metadata_ref).collect();
-        let name = to_c_str(name);
-        let unique_id = to_c_str(unique_id);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateUnionType(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 size_in_bits,
@@ -485,8 +472,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 elements.as_mut_ptr(),
                 elements.len().try_into().unwrap(),
                 runtime_language,
-                unique_id.as_ptr(),
-                unique_id.to_bytes().len(),
+                unique_id.as_ptr() as _,
+                unique_id.len(),
             )
         };
         DICompositeType {
@@ -509,13 +496,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         ty: DIType<'ctx>,
     ) -> DIDerivedType<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateMemberType;
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateMemberType(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 size_in_bits,
@@ -550,16 +536,14 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateStructType;
         let mut elements: Vec<LLVMMetadataRef> =
             elements.into_iter().map(|dt| dt.metadata_ref).collect();
-        let name = to_c_str(name);
-        let unique_id = to_c_str(unique_id);
         let derived_from = derived_from.map_or(std::ptr::null_mut(), |dt| dt.metadata_ref);
         let vtable_holder = vtable_holder.map_or(std::ptr::null_mut(), |dt| dt.metadata_ref);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateStructType(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 size_in_bits,
@@ -570,8 +554,8 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 elements.len().try_into().unwrap(),
                 runtime_language,
                 vtable_holder,
-                unique_id.as_ptr(),
-                unique_id.to_bytes().len(),
+                unique_id.as_ptr() as _,
+                unique_id.len(),
             )
         };
         DICompositeType {
@@ -625,13 +609,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     ) -> DILocalVariable<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateParameterVariable;
 
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateParameterVariable(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 arg_no,
                 file.metadata_ref,
                 line_no,
@@ -660,13 +643,12 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     ) -> DILocalVariable<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateAutoVariable;
 
-        let name = to_c_str(name);
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateAutoVariable(
                 self.builder,
                 scope.metadata_ref,
-                name.as_ptr(),
-                name.to_bytes().len(),
+                name.as_ptr() as _,
+                name.len(),
                 file.metadata_ref,
                 line_no,
                 ty.metadata_ref,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -89,9 +89,7 @@
 use crate::basic_block::BasicBlock;
 use crate::context::Context;
 use crate::module::Module;
-use crate::values::AsValueRef;
-use crate::values::BasicValueEnum;
-use crate::values::{InstructionValue, PointerValue};
+use crate::values::{AsValueRef, BasicValueEnum, InstructionValue, PointerValue};
 pub use llvm_sys::debuginfo::LLVMDWARFTypeEncoding;
 use llvm_sys::debuginfo::LLVMDebugMetadataVersion;
 use llvm_sys::prelude::{LLVMDIBuilderRef, LLVMMetadataRef};

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -451,7 +451,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         size_in_bits: u64,
         align_in_bits: u32,
         flags: DIFlags,
-        elements: Vec<DIType<'ctx>>,
+        elements: &[DIType<'ctx>],
         runtime_language: u32,
         unique_id: &str,
     ) -> DICompositeType<'ctx> {

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -486,7 +486,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
-    /// Create debug info for a (non-static) member.
+    /// Create a type for a non-static member.
     pub fn create_member_type(
         &self,
         scope: DIScope<'ctx>,
@@ -596,7 +596,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
-    /// Create function parameter variable
+    /// Create function parameter variable.
     pub fn create_parameter_variable(
         &self,
         scope: DIScope<'ctx>,
@@ -628,7 +628,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
-    /// Create local automatic storage variable
+    /// Create local automatic storage variable.
     pub fn create_auto_variable(
         &self,
         scope: DIScope<'ctx>,
@@ -745,7 +745,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         InstructionValue::new(value_ref)
     }
 
-    /// Construct placeholders to be used when building debug info with circular references.
+    /// Construct a placeholders derived type to be used when building debug info with circular references.
     ///
     /// All placeholders must be replaced before calling finalize() otherwise we will panic!().
     pub fn create_placeholder_derived_type(&mut self, context: &Context) -> DIDerivedType<'ctx> {
@@ -777,8 +777,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     /// Construct any deferred debug info descriptors. May generate invalid metadata if debug info
     /// is incomplete. Module/function verification can then fail.
     ///
-    /// Call before any kind of code generation (including verification). Can be called more than
-    /// once.
+    /// Call before any kind of code generation (including verification). Can be called more than once.
     pub fn finalize(&self) {
         if !self.placeholders.is_empty() {
             panic!("Can't finalize debug info builder with outstanding placeholder types!");
@@ -879,7 +878,7 @@ impl<'ctx> AsDIScope<'ctx> for DIType<'ctx> {
     }
 }
 
-/// A debug info typedef, created by `create_typedef` method of `DebugInfoBuilder`
+/// A wrapper around a single type, such as a typedef or member type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DIDerivedType<'ctx> {
     pub(crate) metadata_ref: LLVMMetadataRef,
@@ -928,7 +927,7 @@ impl<'ctx> AsDIScope<'ctx> for DIBasicType<'ctx> {
         }
     }
 }
-/// A debug info union type, created by `create_union_type` method of `DebugInfoBuilder`
+/// A wrapper around an array of types, such as a union or struct.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DICompositeType<'ctx> {
     pub(crate) metadata_ref: LLVMMetadataRef,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -689,7 +689,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         InstructionValue::new(value_ref)
     }
 
-    /// Insert a variable declaration (`llvm.dbg.declare` intrinsic)  at the end of `block`
+    /// Insert a variable declaration (`llvm.dbg.declare` intrinsic) at the end of `block`
     pub fn insert_declare_at_end(
         &self,
         storage: PointerValue<'ctx>,
@@ -788,10 +788,10 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     }
 
     /// Construct any deferred debug info descriptors. May generate invalid metadata if debug info
-    /// is incomplete.  Module/function verification can then fail.
+    /// is incomplete. Module/function verification can then fail.
     ///
     /// Call before any kind of code generation (including verification). Can be called more than
-    /// one time.
+    /// once.
     pub fn finalize(&self) {
         use llvm_sys::debuginfo::LLVMDIBuilderFinalize;
         if !self.placeholders.is_empty() {

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -492,16 +492,14 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
     pub fn create_subroutine_type(
         &self,
         file: DIFile<'ctx>,
-        return_type: DIType<'ctx>,
-        parameter_types: Vec<DIType<'ctx>>,
+        return_type: Option<DIType<'ctx>>,
+        parameter_types: &[DIType<'ctx>],
         flags: DIFlags,
     ) -> DISubroutineType<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateSubroutineType;
-        let mut p = [return_type]
-            .iter()
-            .map(|t| t.metadata_ref)
-            .chain(parameter_types.into_iter().map(|t| t.metadata_ref))
-            .collect::<Vec<LLVMMetadataRef>>();
+        let mut p = vec![return_type
+                         .map_or(std::ptr::null_mut(), |t| t.metadata_ref)];
+        p.append(&mut parameter_types.into_iter().map(|t| t.metadata_ref).collect::<Vec<LLVMMetadataRef>>());
         let metadata_ref = unsafe {
             LLVMDIBuilderCreateSubroutineType(
                 self.builder,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -44,7 +44,7 @@
 //!      /* parameter types */ vec![],
 //!      inkwell::debug_info::DIFlags::Public,
 //!  );
-//!  let func_scope: DISubProgram<'_> = dibuilder.create_function(
+//!  let func_scope: DISubprogram<'_> = dibuilder.create_function(
 //!      /* scope */ compile_unit.as_debug_info_scope(),
 //!      /* func name */ "main",
 //!      /* linkage_name */ None,
@@ -58,7 +58,7 @@
 //!      /* is_optimized */ false,
 //!  );
 //! ```
-//! The `DISubProgram` value must be attached to the generated `FunctionValue`:
+//! The `DISubprogram` value must be attached to the generated `FunctionValue`:
 //! ```ignore
 //! /* after creating function: */
 //!     let fn_val = module.add_function(fn_name_str, fn_type, None);
@@ -233,7 +233,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         scope_line: u32,
         flags: DIFlags,
         is_optimized: bool,
-    ) -> DISubProgram<'ctx> {
+    ) -> DISubprogram<'ctx> {
         use llvm_sys::debuginfo::LLVMDIBuilderCreateFunction;
         let linkage_name = to_c_str(linkage_name.unwrap_or(name));
         let name = to_c_str(name);
@@ -256,7 +256,7 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
                 is_optimized as _,
             )
         };
-        DISubProgram {
+        DISubprogram {
             metadata_ref,
             _marker: PhantomData,
         }
@@ -869,12 +869,12 @@ impl<'ctx> AsDIScope<'ctx> for DICompileUnit<'ctx> {
 
 /// Function body scope for debug info
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct DISubProgram<'ctx> {
+pub struct DISubprogram<'ctx> {
     pub(crate) metadata_ref: LLVMMetadataRef,
     pub(crate) _marker: PhantomData<&'ctx Context>,
 }
 
-impl<'ctx> AsDIScope<'ctx> for DISubProgram<'ctx> {
+impl<'ctx> AsDIScope<'ctx> for DISubprogram<'ctx> {
     fn as_debug_info_scope(self) -> DIScope<'ctx> {
         DIScope {
             metadata_ref: self.metadata_ref,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -635,6 +635,41 @@ impl<'ctx> DebugInfoBuilder<'ctx> {
         }
     }
 
+    /// Create local automatic storage variable
+    pub fn create_auto_variable(
+        &self,
+        scope: DIScope<'ctx>,
+        name: &str,
+        file: DIFile<'ctx>,
+        line_no: u32,
+        ty: DIType<'ctx>,
+        always_preserve: bool,
+        flags: DIFlags,
+        align_in_bits: u32
+    ) -> DILocalVariable<'ctx> {
+        use llvm_sys::debuginfo::LLVMDIBuilderCreateAutoVariable;
+
+        let name = to_c_str(name);
+        let metadata_ref = unsafe {
+            LLVMDIBuilderCreateAutoVariable(
+                self.builder,
+                scope.metadata_ref,
+                name.as_ptr(),
+                name.to_bytes().len(),
+                file.metadata_ref,
+                line_no,
+                ty.metadata_ref,
+                always_preserve as _,
+                flags.into(),
+                align_in_bits,
+            )
+        };
+        DILocalVariable {
+            metadata_ref,
+            _marker: PhantomData,
+        }
+    }
+
     /// Insert a variable declaration (`llvm.dbg.declare`) before a specified instruction.
     pub fn insert_declare_before_instruction(
         &self,

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -999,7 +999,7 @@ impl<'ctx> AsDIScope<'ctx> for DILexicalBlock<'ctx> {
 ///
 /// - line, column
 /// - scope
-/// - is inlined
+/// - inlined at
 ///
 /// Created by `create_debug_location` of `DebugInfoBuilder` and consumed by
 /// `set_current_debug_location` of `Builder`.

--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -529,6 +529,7 @@ pub mod experimental {
     use llvm_sys::orc::{LLVMOrcCreateInstance, LLVMOrcDisposeInstance, LLVMOrcJITStackRef, LLVMOrcAddEagerlyCompiledIR, LLVMOrcAddLazilyCompiledIR, LLVMOrcGetErrorMsg, LLVMOrcGetMangledSymbol, LLVMOrcDisposeMangledSymbol};
 
     use crate::module::Module;
+    use crate::support::to_c_str;
     use crate::targets::TargetMachine;
 
     use std::mem::MaybeUninit;

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -743,14 +743,13 @@ impl Target {
         }
     }
 
-    // REVIEW: As it turns out; RISCV was accidentally built by default in 4.0 since
-    // it was meant to be marked experimental and so it was later removed from default
-    // builds in 5.0+. Since llvm-sys doesn't officially support any experimental targets
-    // we're going to make this 4.0 only for now so that it doesn't break test builds.
-    // We can revisit this issue if someone wants RISCV support in inkwell, or if
-    // llvm-sys starts supporting experimental llvm targets. See
-    // https://lists.llvm.org/pipermail/llvm-dev/2017-August/116347.html for more info
-    #[llvm_versions(4.0)]
+    // RISCV was accidentally built by default in 4.0 since it was meant to be marked
+    // experimental and so it was later removed from default builds in 5.0 until it was
+    // officially released in 9.0 Since llvm-sys doesn't officially support any experimental
+    // targets we're going to make this 9.0+ only. See
+    // https://lists.llvm.org/pipermail/llvm-dev/2017-August/116347.html for more info.
+    #[cfg(feature = "target-riscv")]
+    #[llvm_versions(9.0..=latest)]
     pub fn initialize_riscv(config: &InitializationConfig) {
         use llvm_sys::target::{
             LLVMInitializeRISCVTarget, LLVMInitializeRISCVTargetInfo, LLVMInitializeRISCVTargetMC,

--- a/src/values/fn_value.rs
+++ b/src/values/fn_value.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use crate::attributes::{Attribute, AttributeLoc};
 use crate::basic_block::BasicBlock;
 #[llvm_versions(7.0..=latest)]
-use crate::debug_info::DISubProgram;
+use crate::debug_info::DISubprogram;
 use crate::module::Linkage;
 use crate::support::{to_c_str, LLVMString};
 use crate::types::{FunctionType, PointerType};
@@ -511,19 +511,19 @@ impl<'ctx> FunctionValue<'ctx> {
 
     /// Set the debug info descriptor
     #[llvm_versions(7.0..=latest)]
-    pub fn set_subprogram(self, subprogram: DISubProgram<'ctx>) {
+    pub fn set_subprogram(self, subprogram: DISubprogram<'ctx>) {
         unsafe { LLVMSetSubprogram(self.as_value_ref(), subprogram.metadata_ref) }
     }
 
     /// Get the debug info descriptor
     #[llvm_versions(7.0..=latest)]
-    pub fn get_subprogram(self) -> Option<DISubProgram<'ctx>> {
+    pub fn get_subprogram(self) -> Option<DISubprogram<'ctx>> {
         let metadata_ref = unsafe { LLVMGetSubprogram(self.as_value_ref()) };
 
         if metadata_ref.is_null() {
             None
         } else {
-            Some(DISubProgram {
+            Some(DISubprogram {
                 metadata_ref,
                 _marker: PhantomData,
             })

--- a/src/values/instruction_value.rs
+++ b/src/values/instruction_value.rs
@@ -1,9 +1,11 @@
 use either::{Either, Either::{Left, Right}};
-use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst, LLVMGetMetadata, LLVMHasMetadata, LLVMSetMetadata, LLVMIsAAtomicRMWInst, LLVMIsAAtomicCmpXchgInst};
+use llvm_sys::core::{LLVMGetAlignment, LLVMSetAlignment, LLVMGetInstructionOpcode, LLVMIsTailCall, LLVMGetPreviousInstruction, LLVMGetNextInstruction, LLVMGetInstructionParent, LLVMInstructionEraseFromParent, LLVMInstructionClone, LLVMSetVolatile, LLVMGetVolatile, LLVMGetNumOperands, LLVMGetOperand, LLVMGetOperandUse, LLVMSetOperand, LLVMValueAsBasicBlock, LLVMIsABasicBlock, LLVMGetICmpPredicate, LLVMGetFCmpPredicate, LLVMIsAAllocaInst, LLVMIsALoadInst, LLVMIsAStoreInst, LLVMGetMetadata, LLVMHasMetadata, LLVMSetMetadata};
 #[llvm_versions(3.8..=latest)]
 use llvm_sys::core::{LLVMGetOrdering, LLVMSetOrdering};
 #[llvm_versions(3.9..=latest)]
 use llvm_sys::core::LLVMInstructionRemoveFromParent;
+#[llvm_versions(10.0..=latest)]
+use llvm_sys::core::{LLVMIsAAtomicRMWInst, LLVMIsAAtomicCmpXchgInst};
 use llvm_sys::LLVMOpcode;
 use llvm_sys::prelude::LLVMValueRef;
 
@@ -113,9 +115,11 @@ impl<'ctx> InstructionValue<'ctx> {
     fn is_a_alloca_inst(self) -> bool {
         !unsafe { LLVMIsAAllocaInst(self.as_value_ref()) }.is_null()
     }
+    #[llvm_versions(10.0..=latest)]
     fn is_a_atomicrmw_inst(self) -> bool {
         !unsafe { LLVMIsAAtomicRMWInst(self.as_value_ref()) }.is_null()
     }
+    #[llvm_versions(10.0..=latest)]
     fn is_a_cmpxchg_inst(self) -> bool {
         !unsafe { LLVMIsAAtomicCmpXchgInst(self.as_value_ref()) }.is_null()
     }


### PR DESCRIPTION
## Description

 * Rebase to inkwell master.
 * Implement AsDIScope for DITypes.
 * Make the return_type in `create_subroutine_type` Option so that we can make void-returning functions.
 * Add the ability to create structs and members. The LLVM representation of this uses circular metadata, so we add the ability to create placeholder DIDerviedTypes to use as struct members, and to replace those placeholders later. To help with safety, we store these in a vec on DIBuilder and check that it's empty upon `finalize`.

TODO: implement the rest of the review feedback on https://github.com/TheDan64/inkwell/pull/182 .

## Related Issue

https://github.com/TheDan64/inkwell/issues/180

## How This Has Been Tested

Obviously this is missing tests which will need to be added.

I've started using this in a branch of `wasmerio/wasmer` though it's not exhaustively tested there either. At least I can add line number info without hitting any verifier failures or assertions in LLVM 10.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/TheDan64/inkwell/blob/master/.github/CONTRIBUTING.md)
